### PR TITLE
(wip) Now using helix as default IDE/text editor

### DIFF
--- a/dotfiles/helix/languages.toml
+++ b/dotfiles/helix/languages.toml
@@ -34,15 +34,31 @@ args = ["server"]
 name = "json"
 language-servers = ["vscode-json-language-server"]
 auto-format = true
-indent = { tab-width = 4, unit = " " }
+indent = { tab-width = 2, unit = " " }
+formatter = { command = "prettier", args = ["--parser", "json"]}
 
-[language-server.vscode-json-language-server]
-command = "vscode-json-language-server"
-args = ["--stdio"]
+# Old setup before using prettier - may be handy
+# [language-server.vscode-json-language-server]
+# command = "vscode-json-language-server"
+# args = ["--stdio"]
 
-[language-server.vscode-json-language-server.config]
-json = { validate = { enable = true }, format = { enable = true } }
-provideFormatter = true
+# [language-server.vscode-json-language-server.config]
+# json = { validate = { enable = true }, format = { enable = true } }
+# provideFormatter = true
+
+# ----------------------------
+
+[[language]]
+name = "rust"
+auto-format = true
+formatter = { command = "rustfmt"}
+
+# ----------------------------
+
+[[language]]
+name = "nix"
+auto-format = true
+formatter = { command = "alejandra"}
 
 # ----------------------------
 
@@ -54,6 +70,28 @@ formatter = { command = "shfmt" }
 # ----------------------------
 
 [[language]]
-name = "rust"
+name = "yaml"
 auto-format = true
-formatter = { command = "rustfmt"}
+formatter = { command = "prettier", args = ["--parser", "yaml"]}
+
+[language-server.yaml-language-server]
+# Custom CFN Tags below for YAML
+config = { yaml = { customTags = [
+    "!Ref scalar",
+    "!Ref sequence",
+    "!Ref mapping",
+    "!Sub scalar",
+    "!Sub sequence",
+    "!Sub mapping",
+    "!GetAtt scalar",
+    "!GetAtt sequence",
+    "!GetAtt mapping",
+    "!Join sequence",
+    "!FindInMap sequence",
+    "!Select sequence",
+    "!Split sequence",
+    "!ImportValue scalar",
+    "!ImportValue sequence",
+    "!ImportValue mapping",
+    "!GetAZs sequence"
+] } }

--- a/home/astra/beltanimal.nix
+++ b/home/astra/beltanimal.nix
@@ -3,7 +3,7 @@
   imports = [
 
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global

--- a/home/astra/hummingbird.nix
+++ b/home/astra/hummingbird.nix
@@ -3,7 +3,7 @@
   imports = [
 
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global

--- a/home/bb/anya.nix
+++ b/home/bb/anya.nix
@@ -8,7 +8,7 @@
 }: {
   imports = [
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global/sh.nix

--- a/home/bb/beltanimal.nix
+++ b/home/bb/beltanimal.nix
@@ -8,7 +8,7 @@
 }: {
   imports = [
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global/sh.nix

--- a/home/common/global/default.nix
+++ b/home/common/global/default.nix
@@ -1,11 +1,11 @@
 # Common Home Manager config for ALL users
-{ ... }:
-{
+{...}: {
   imports = [
     ./sh.nix
     ./git.nix
     ./starship.nix
     ./terminal.nix
     ./packages.nix
+    ./helix.nix
   ];
 }

--- a/home/common/global/helix.nix
+++ b/home/common/global/helix.nix
@@ -1,0 +1,33 @@
+# Helix Home-Manager IDE Config
+{pkgs, ...}: {
+  home.packages = with pkgs; [
+    unstable.helix # Code Editor
+
+    # Language Servers (and/or similar)
+    vscode-langservers-extracted # support for many others
+    yaml-language-server
+    unstable.nixd # LSP
+    pyright # Python
+    taplo # TOML
+    bash-language-server # bash
+    shfmt # shell/bash formatter
+    alejandra # Nix Formatter
+    nodePackages.prettier # YAML formatter
+    typescript-language-server # TypeScript
+  ];
+
+  # To stop myself from automatically using `code .`
+  programs.zsh.shellAliases = {
+    vscode = "/usr/local/bin/code";
+    code = "${pkgs.unstable.helix}/bin/hx";
+  };
+
+  # Set Helix as the default editor (for git operations and such)
+  home.sessionVariables.EDITOR = "hx";
+
+  home.file = {
+    # Helix IDE config files
+    ".config/helix/config.toml".source = ../../../dotfiles/helix/config.toml;
+    ".config/helix/languages.toml".source = ../../../dotfiles/helix/languages.toml;
+  };
+}

--- a/home/common/global/packages.nix
+++ b/home/common/global/packages.nix
@@ -16,7 +16,6 @@
     jq # JSON parsing utility
     tldr # man for dummies
     cachix # nix binary cache
-    unstable.helix # Code Editor
 
     # Desktop Applications
     firefox

--- a/home/common/global/sh.nix
+++ b/home/common/global/sh.nix
@@ -1,6 +1,8 @@
-{ pkgs, username, ... }:
-
-let
+{
+  pkgs,
+  username,
+  ...
+}: let
   myAliases = {
     # Replacements for some GNU Utils
     top = "${pkgs.bottom}/bin/btm";
@@ -13,20 +15,16 @@ let
     grep = "${pkgs.ripgrep}/bin/rg";
     rg = "${pkgs.unstable.ripgrep}/bin/rg";
     vi = "${pkgs.vim}/bin/vim";
-    cd = "z";   # zoxide
+    cd = "z"; # zoxide
     cdi = "zi"; # zoxide
 
     # My custom Aliases
     ll = "ls -la";
-    vscode = "/usr/local/bin/code"; # to stop myself from automatically using `code .`
-    code = "${pkgs.unstable.helix}/bin/hx"; # to stop myself from automatically using `code .`
   };
 
-  myEnvVars = {
-    EDITOR = "hx";
-  };
-in
-{
+  # For when it's needed
+  myEnvVars = {};
+in {
   # Environment Variables
   home.sessionVariables = myEnvVars;
 

--- a/home/tk/anya.nix
+++ b/home/tk/anya.nix
@@ -11,7 +11,7 @@
 }: {
   imports = [
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global
@@ -51,18 +51,6 @@
     unstable.clang
     unstable.mold # even better linker
 
-    # Nix
-    alejandra # Formatter
-
-    # Language Servers (and/or similar)
-    vscode-langservers-extracted # support for many others
-    yaml-language-server
-    unstable.nixd # LSP
-    pyright # Python
-    taplo # TOML
-    bash-language-server # bash
-    shfmt # shell/bash formatter
-
     # Desktop Applications
     unstable.element-desktop # Matrix client
     unstable.makemkv # DVD Ripper
@@ -81,7 +69,6 @@
     # Games
     unstable.openrct2 # RollerCoaster Tycoon 2
     openttd # Transport Tycoon Deluxe
-
   ];
 
   # Syncthing (personal cloud)
@@ -110,10 +97,6 @@
     # Keypad Rebind keys
     ".config/input-remapper-2/presets/Razer Razer Nostromo/nostromo.json".source = ../../dotfiles/input-remapper/nostromo.json;
     ".config/input-remapper-2/presets/Razer Razer Tartarus V2/tartarus.json".source = ../../dotfiles/input-remapper/tartarus.json;
-
-    # Helix IDE config files
-    ".config/helix/config.toml".source = ../../dotfiles/helix/config.toml;
-    ".config/helix/languages.toml".source = ../../dotfiles/helix/languages.toml;
   };
 
   programs.home-manager.enable = true;

--- a/home/tk/beltanimal.nix
+++ b/home/tk/beltanimal.nix
@@ -3,7 +3,7 @@
   imports = [
 
     # Required for Home Manager
-    inputs.plasma-manager6.homeManagerModules.plasma-manager
+    inputs.plasma-manager6.homeModules.plasma-manager
 
     # Repo Home Manager Modules
     ../common/global


### PR DESCRIPTION
- moved LSPs used for helix from anya to global
- moved helix config files from anya to global
- added helix.nix module and included in globals, which most home-manager hosts use
- applied formatting for home/commong/global/sh.nix